### PR TITLE
Option to pass custom stroke styling color for bounding boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ interface Props {
     height: number, // height of the labeling window
     width: number, // width of the labeling window
     types: Array<string>, // annotation types
+    typesColor?: Array<string>, // colors for annotation types
     asyncUpload?: (data: any) => Promise<any>, // will be invoked when uploading. you can switch to next image in this callback
     disableAnnotation?: boolean, // default false
     defaultType?: string, // default type, can be empty

--- a/src/Annotator.tsx
+++ b/src/Annotator.tsx
@@ -12,6 +12,7 @@ interface Props {
     height: number, // height of the labeling window
     width: number, // width of the labeling window
     types: Array<string>, // annotation types
+    typesColor: Array<string>, // colors for annotation types
     asyncUpload?: (data: any) => Promise<any>, // will be invoked when uploading. you can switch to next image in this callback
     disableAnnotation?: boolean, // default false
     defaultType?: string, // default type, can be empty
@@ -869,6 +870,18 @@ export class Annotator extends React.Component<Props, State>{
         }
 
         this.ctx.fillStyle = "#f00";
+
+        // find the correct stroke style for a bounding box
+        const findAnnotationIndex = (annotation: String) =>
+        this.props.types.findIndex((type) => type === annotation)
+
+        const getStrokeStyle = (annotation: String) => {
+            const { typesColor } = this.props
+            if (!typesColor) return '#555'
+            const strokeStyle = typesColor[findAnnotationIndex(annotation)]
+            return strokeStyle ? strokeStyle : '#555'
+        }
+
         for (let i = 0; i < this.boxes.length; i++) {
             let box = this.boxes[i];
             const fontSize = 30 / this.scale.x;
@@ -879,7 +892,7 @@ export class Annotator extends React.Component<Props, State>{
                     this.ctx.strokeRect(box.x, box.y, box.w, box.h);
                 } else {
                     this.ctx.lineWidth = 5;
-                    this.ctx.strokeStyle = '#555';
+                    this.ctx.strokeStyle = getStrokeStyle(box.annotation);
                     this.ctx.strokeRect(box.x, box.y, box.w, box.h);
 
                     this.ctx.fillStyle = 'rgba(255, 100, 145, 0.45)';
@@ -898,7 +911,7 @@ export class Annotator extends React.Component<Props, State>{
                 }
             } else if (box.hover) {
                 this.ctx.lineWidth = 5;
-                this.ctx.strokeStyle = '#555';
+                this.ctx.strokeStyle = getStrokeStyle(box.annotation);
                 this.ctx.strokeRect(box.x, box.y, box.w, box.h);
 
                 this.ctx.fillStyle = 'rgba(255, 100, 145, 0.3)';
@@ -910,7 +923,7 @@ export class Annotator extends React.Component<Props, State>{
                 this.ctx.fillText(box.annotation, box.x + box.w / 2, box.y + box.h / 2 + fontSize / 2);
             } else {
                 this.ctx.lineWidth = 5;
-                this.ctx.strokeStyle = '#555';
+                this.ctx.strokeStyle = getStrokeStyle(box.annotation);
                 this.ctx.strokeRect(box.x, box.y, box.w, box.h);
 
                 this.ctx.fillStyle = 'rgba(200, 200, 200, 0.5)';

--- a/src/Demo.tsx
+++ b/src/Demo.tsx
@@ -35,6 +35,7 @@ const Component: React.FC = (props) => {
           console.log(labeledData);
         }}
         types={['A', 'B', 'Cylinder']}
+        typesColor={['#555','#189','#000']}
         defaultType={"Cylinder"}
         sceneTypes={['1', '2', '3']}
         defaultSceneType={defaultSceneType}
@@ -52,7 +53,7 @@ const Component: React.FC = (props) => {
           y: 305,
           w: 65,
           h: 61,
-          annotation: 'A'
+          annotation: 'A',
         }]}
         disableAnnotation={false}
       />


### PR DESCRIPTION
An optional prop "typesColor'' exposed to enable users to pass an array with custom colors for annotation types. This can help distinguish bounding boxes visually if the defaultBoxes array is large and diverse.
If an array is not provided, the index position contains an empty string or if an element is missing, the stroke will fallback to '#555'.

This PR implements the functionality for #15 